### PR TITLE
fix blurred wallpaper not being generated

### DIFF
--- a/awesome/components/pastel/wallpaper.lua
+++ b/awesome/components/pastel/wallpaper.lua
@@ -48,7 +48,7 @@ if not exists(blurred_wallpaper) then
       text = "Generating blurred wallpaper..."
    })
    -- uses image magick to create a blurred version of the wallpaper
-   awful.spawn.with_shell("convert -filter Gaussian -blur 0x30 " .. wallpaper .. " " .. blurredWallpaper)
+   awful.spawn.with_shell("convert -filter Gaussian -blur 0x30 " .. wallpaper .. " " .. blurred_wallpaper)
 end
 
 


### PR DESCRIPTION
Small typo fix. The previous code used the wrong variable name for the blurred wallpaper path, causing awesome to crash.