### PR TITLE
Make battery listener only listen to device power

### DIFF
--- a/awesome/widgets/battery.lua
+++ b/awesome/widgets/battery.lua
@@ -80,7 +80,7 @@ end
 
 local last_battery_check = os.time()
 
-watch("acpi -i", 1,
+watch('bash -c \'acpi -i | grep -E "^Battery [0-9]+: ([^%]+%)$|(.+remaining)$" --color=never\'', 1,
    function(_, stdout)
       local battery_info = {}
       local capacities = {}

--- a/awesome/widgets/battery.lua
+++ b/awesome/widgets/battery.lua
@@ -80,7 +80,7 @@ end
 
 local last_battery_check = os.time()
 
-watch('bash -c \'acpi -i | grep -E "^Battery [0-9]+: ([^%]+%)$|(.+remaining)$" --color=never\'', 1,
+watch('bash -c \'acpi -i | grep -E "^Battery [0-9]+: ([^%]+%)$|(.+remaining)$|(.+charged)$" --color=never\'', 1,
    function(_, stdout)
       local battery_info = {}
       local capacities = {}


### PR DESCRIPTION
On my laptop, I frequently use wireless devices, which also show up on acpi -i, so the current implementation of the watch script did not work for me. This change makes it so it only takes the lines that indicate a rate of which a % sign is at the end of the string or if 'remaining' is at the end of the string.

Not sure if this covers all use cases, but it works for me, because my wireless devices report 'rate information unavailable'.