### PR TITLE
Added right click for toggling bluetooth

### DIFF
--- a/awesome/widgets/bluetooth.lua
+++ b/awesome/widgets/bluetooth.lua
@@ -42,6 +42,15 @@ widget_button:buttons(
          function()
             awful.spawn("blueman-manager")
          end
+      ),
+      awful.button({}, 3, nil,
+         function()
+            if checker ~= nil then
+               awful.spawn.easy_async_with_shell('bluetoothctl power off')
+            else
+               awful.spawn.easy_async_with_shell('bluetoothctl power on')
+            end
+         end
       )
    )
 )
@@ -63,10 +72,10 @@ awful.tooltip(
 )
 
 local last_bluetooth_check = os.time()
-watch("bluetoothctl --monitor list", 5,
+watch("bluetoothctl show", 5,
    function(_, stdout)
       -- Check if there  bluetooth
-      checker = stdout:match("Controller") -- If 'Controller' string is detected on stdout
+      checker = stdout:match("Powered: yes") -- If Controller powered: yes string is detected on stdout
       local widget_icon_name
       if (checker ~= nil) then
          widget_icon_name = "bluetooth"


### PR DESCRIPTION
Hi, I'm using the rice for a good time, and I do find it really cool

I just added a simple feature, right mouse click in the Bluetooth widget to toggle it off / on

Also I changed the bluetoothctl monitor command and the string match, because in my case if it's powered or not, the Controller string is always there

I'm running a heavily modified version of your dots, and the base dots didn't work for me at the start, but with this simple widget I don't think that there will be any incompatibility